### PR TITLE
Adding support for Linux

### DIFF
--- a/gh-artifact-purge
+++ b/gh-artifact-purge
@@ -68,10 +68,17 @@ process_repo() {
 			EXPIRED=$(artifact '.expired')
 
 			# Convert dates for easier comparison, calculate new expiration date
-			CREATED_SECS=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$CREATED" '+%s')
-			EXPIRES_SECS=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$EXPIRES" '+%s')
-			AMENDED=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' -v"+${RETENTION}d" "$CREATED" '+%Y-%m-%dT%H:%M:%SZ')
-			AMENDED_SECS=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' -v"+${RETENTION}d" "$CREATED" '+%s')
+			if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+				CREATED_SECS=$(date -d "$CREATED" '+%s')
+				EXPIRES_SECS=$(date -d "$EXPIRES" '+%s')
+				AMENDED=$(date -d "${CREATED} +${RETENTION} days" '+%Y-%m-%dT%H:%M:%SZ')
+				AMENDED_SECS=$(date -d "$AMENDED" '+%s')
+			elif [[ "$OSTYPE" == "darwin"* ]]; then
+				CREATED_SECS=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$CREATED" '+%s')
+				EXPIRES_SECS=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$EXPIRES" '+%s')
+				AMENDED=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' -v"+${RETENTION}d" "$CREATED" '+%Y-%m-%dT%H:%M:%SZ')
+				AMENDED_SECS=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$AMENDED" '+%s')
+			fi
 
 			# Lookup workflow run information
 			WORKFLOW_RUN_DATA=$(gh api "/repos/$NWO/actions/runs/$WORKFLOW_RUN_ID" --jq '. | @base64')
@@ -172,8 +179,14 @@ if test "$#" -lt 2; then
 fi
 
 # Capture timestamp for evaluation purposes
-NOW=$(date -j '+%Y-%m-%dT%H:%M:%SZ')
-NOW_SECS=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$NOW" '+%s')
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+	NOW=$(date '+%Y-%m-%dT%H:%M:%SZ')
+	NOW_SECS=$(date -d "$NOW" '+%s')
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+	NOW=$(date -j '+%Y-%m-%dT%H:%M:%SZ')
+	NOW_SECS=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$NOW" '+%s')
+fi
+
 printf "Evaluating artifacts against %s (%s seconds)\n" $NOW $NOW_SECS
 
 # Process owner or owner/repo appropriately


### PR DESCRIPTION
closes #1 

- enhanced date logic to differentiate GNU date versus BSD date

### Mac OS

```shell
andyfeller/gh-artifact-purge ‹issue-1-linux-support*›$ ./gh-artifact-purge octodemo 5
Evaluating artifacts against 2023-06-23T15:30:11Z (1687548611 seconds)
octodemo:  processing 2,181 repositories
octodemo/ReadingTimeDemo:  processing
octodemo/github-craftwork-azure:  processing
octodemo/github-craftwork-azure:  processing 1 artifacts
octodemo/github-craftwork-azure:  skipping (expired) 582088013
    Name:      Analyses Results (SARIF)
    ID:        582088013
    Size:      748393 bytes
    Created:   2023-03-03T12:53:33Z  (1677866013 seconds)
    Amended:   2023-03-08T12:53:33Z  (1678298013 seconds)
    Expires:   2023-06-01T12:52:51Z  (1685638371 seconds)
    Expired:   true
    Workflow:
        Name:  CodeQL
        ID:    50093855
        Path:  dynamic/github-code-scanning/codeql
        State: active
octodemo/GitHubAppDotnetSample:  processing
octodemo/actions-beta:  processing
octodemo/actions-test:  processing
octodemo/MySampleExpressApp:  processing
octodemo/MySampleExpressApp:  processing 1 artifacts
octodemo/MySampleExpressApp:  skipping (expired) 582088326
    Name:      Analyses Results (SARIF)
    ID:        582088326
    Size:      1327881 bytes
    Created:   2023-03-03T12:53:50Z  (1677866030 seconds)
    Amended:   2023-03-08T12:53:50Z  (1678298030 seconds)
    Expires:   2023-06-01T12:52:37Z  (1685638357 seconds)
    Expired:   true
    Workflow:
        Name:  CodeQL
        ID:    50093856
        Path:  dynamic/github-code-scanning/codeql
        State: active
octodemo/permission-demo:  processing
octodemo/ssokey-whitelister:  processing
octodemo/ford-demo:  processing
octodemo/Internal-repo:  processing
```

### Ubuntu 18.04

> **Note**
> Testing was done on a fresh Vagrant VirtualBox VM.

```shell
vagrant@ubuntu-bionic:/vagrant$ ./gh-artifact-purge octodemo 5
Evaluating artifacts against 2023-06-23T19:31:16Z (1687548676 seconds)
octodemo:  processing 2181 repositories
octodemo/ReadingTimeDemo:  processing
octodemo/github-craftwork-azure:  processing
octodemo/github-craftwork-azure:  processing 1 artifacts
octodemo/github-craftwork-azure:  skipping (expired) 582088013
    Name:      Analyses Results (SARIF)
    ID:        582088013
    Size:      748393 bytes
    Created:   2023-03-03T12:53:33Z  (1677848013 seconds)
    Amended:   2023-03-08T12:53:33Z  (1678280013 seconds)
    Expires:   2023-06-01T12:52:51Z  (1685623971 seconds)
    Expired:   true
    Workflow:
        Name:  CodeQL
        ID:    50093855
        Path:  dynamic/github-code-scanning/codeql
        State: active
octodemo/GitHubAppDotnetSample:  processing
octodemo/actions-beta:  processing
octodemo/actions-test:  processing
octodemo/MySampleExpressApp:  processing
octodemo/MySampleExpressApp:  processing 1 artifacts
octodemo/MySampleExpressApp:  skipping (expired) 582088326
    Name:      Analyses Results (SARIF)
    ID:        582088326
    Size:      1327881 bytes
    Created:   2023-03-03T12:53:50Z  (1677848030 seconds)
    Amended:   2023-03-08T12:53:50Z  (1678280030 seconds)
    Expires:   2023-06-01T12:52:37Z  (1685623957 seconds)
    Expired:   true
    Workflow:
        Name:  CodeQL
        ID:    50093856
        Path:  dynamic/github-code-scanning/codeql
        State: active
octodemo/permission-demo:  processing
octodemo/ssokey-whitelister:  processing
octodemo/ford-demo:  processing
octodemo/Internal-repo:  processing
```
