### PR TITLE
Making gh api calls more Git Bash friendly

### DIFF
--- a/gh-artifact-purge
+++ b/gh-artifact-purge
@@ -31,7 +31,7 @@ process_repo() {
 
 	while true; do
 		set +e
-		artifacts_data=$(gh api "/repos/$NWO/actions/artifacts" -X GET -F page=$PAGE -F per_page=100 --jq '. | @base64')
+		artifacts_data=$(gh api "repos/$NWO/actions/artifacts" -X GET -F page=$PAGE -F per_page=100 --jq '. | @base64')
 		artifacts_error=$?
 		set -e
 
@@ -81,7 +81,7 @@ process_repo() {
 			fi
 
 			# Lookup workflow run information
-			WORKFLOW_RUN_DATA=$(gh api "/repos/$NWO/actions/runs/$WORKFLOW_RUN_ID" --jq '. | @base64')
+			WORKFLOW_RUN_DATA=$(gh api "repos/$NWO/actions/runs/$WORKFLOW_RUN_ID" --jq '. | @base64')
 
 			workflow_run() {
 				echo -n $WORKFLOW_RUN_DATA | base64 --decode | jq -r "${1}"
@@ -90,7 +90,7 @@ process_repo() {
 			WORKFLOW_ID=$(workflow_run '.workflow_id')
 
 			# Lookup workflow information related to workflow run
-			WORKFLOW_DATA=$(gh api "/repos/$NWO/actions/workflows/$WORKFLOW_ID" --jq '. | @base64')
+			WORKFLOW_DATA=$(gh api "repos/$NWO/actions/workflows/$WORKFLOW_ID" --jq '. | @base64')
 
 			workflow() {
 				echo -n $WORKFLOW_DATA | base64 --decode | jq -r "${1}"
@@ -127,7 +127,7 @@ process_repo() {
 				artifact_status 'skipping (within retention)'  # Artifact amended expiration in future
 			elif $RUN; then
 				artifact_status 'deleting'  # Artifact amended expiration in past and in run mode
-				gh api -X DELETE "/repos/$NWO/actions/artifacts/$ID"
+				gh api -X DELETE "repos/$NWO/actions/artifacts/$ID"
 			else
 				artifact_status 'nominating'  # Artifact amended expiration in past and in dryrun mode
 			fi


### PR DESCRIPTION
closes #4 

## Testing

The following testing was done in Git Bash on Windows 11:

```shell
$ ./gh-artifact-purge octodemo 180
Evaluating artifacts against  ( seconds)
octodemo:  processing 2242 repositories
octodemo/ReadingTimeDemo:  processing
octodemo/github-craftwork-azure:  processing
octodemo/github-craftwork-azure:  processing 1 artifacts
octodemo/github-craftwork-azure:  skipping (expired) 582088013
    Name:      Analyses Results (SARIF)
    ID:        582088013
    Size:      748393 bytes
    Created:   2023-03-03T12:53:33Z  ( seconds)
    Amended:     ( seconds)
    Expires:   2023-06-01T12:52:51Z  ( seconds)
    Expired:   true
    Workflow:
        Name:  CodeQL
        ID:    50093855
        Path:  dynamic/github-code-scanning/codeql
        State: active
octodemo/GitHubAppDotnetSample:  processing
octodemo/actions-beta:  processing
octodemo/actions-test:  processing
octodemo/MySampleExpressApp:  processing
octodemo/MySampleExpressApp:  processing 1 artifacts
octodemo/MySampleExpressApp:  skipping (expired) 582088326
    Name:      Analyses Results (SARIF)
    ID:        582088326
    Size:      1327881 bytes
    Created:   2023-03-03T12:53:50Z  ( seconds)
    Amended:     ( seconds)
    Expires:   2023-06-01T12:52:37Z  ( seconds)
    Expired:   true
    Workflow:
        Name:  CodeQL
        ID:    50093856
        Path:  dynamic/github-code-scanning/codeql
        State: active
octodemo/permission-demo:  processing
octodemo/ssokey-whitelister:  processing
octodemo/ford-demo:  processing
octodemo/Internal-repo:  processing
octodemo/security-demo-repo:  processing
octodemo/security-demo-repo:  processing 1 artifacts
octodemo/security-demo-repo:  skipping (expired) 582087757
    Name:      Analyses Results (SARIF)
    ID:        582087757
    Size:      215735 bytes
    Created:   2023-03-03T12:53:21Z  ( seconds)
    Amended:     ( seconds)
    Expires:   2023-06-01T12:52:54Z  ( seconds)
    Expired:   true
    Workflow:
        Name:  CodeQL
        ID:    50093858
        Path:  dynamic/github-code-scanning/codeql
        State: active
```